### PR TITLE
Update Gemspec to specify Sidekiq <3.0.

### DIFF
--- a/sidekiq-rate-limiter.gemspec
+++ b/sidekiq-rate-limiter.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov-rcov"
 
   s.add_dependency "redis"
-  s.add_dependency "sidekiq"
+  s.add_dependency "sidekiq", "~> 2.0"
   s.add_dependency "redis_rate_limiter"
 end


### PR DESCRIPTION
Sidekiq-rate-limiter is not yet compatible with Sidekiq 3.0. This change will prevent Sidekiq 3.0 from being installed by Bundler until compatibility issues can be fixed.
