### PR TITLE
Backwards compatibility with Sidekiq < 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ spec/support/redis/
 dump.rdb
 .pryrc
 .byebug_history
+*.gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.8
+
+gemfile:
+  - 'gemfiles/sidekiq_2.gemfile'
+  - 'gemfiles/sidekiq_3.gemfile'
+  - 'gemfiles/sidekiq_4.gemfile'

--- a/gemfiles/sidekiq_2.gemfile
+++ b/gemfiles/sidekiq_2.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'sidekiq', '~> 2.0'
+
+gemspec path: '../'

--- a/gemfiles/sidekiq_3.gemfile
+++ b/gemfiles/sidekiq_3.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'sidekiq', '~> 3.0'
+
+gemspec path: '../'

--- a/gemfiles/sidekiq_4.gemfile
+++ b/gemfiles/sidekiq_4.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'sidekiq', '~> 4.0'
+
+gemspec path: '../'

--- a/lib/sidekiq-rate-limiter/fetch.rb
+++ b/lib/sidekiq-rate-limiter/fetch.rb
@@ -1,3 +1,5 @@
+require 'sidekiq'
+require 'celluloid' if Sidekiq::VERSION < "4"
 require 'sidekiq/fetch'
 require 'redis_rate_limiter'
 

--- a/spec/sidekiq-rate-limiter/fetch_spec.rb
+++ b/spec/sidekiq-rate-limiter/fetch_spec.rb
@@ -40,8 +40,15 @@ describe Sidekiq::RateLimiter::Fetch do
   end
 
   it 'should retrieve work with strict setting' do
+    timeout =
+      if defined? Sidekiq::BasicFetch::TIMEOUT
+        Sidekiq::BasicFetch::TIMEOUT
+      else
+        Sidekiq::Fetcher::TIMEOUT
+      end
+
     fetch = described_class.new options.merge(:strict => true)
-    fetch.queues_cmd.should eql(["queue:#{queue}", "queue:#{another_queue}", Sidekiq::BasicFetch::TIMEOUT])
+    fetch.queues_cmd.should eql(["queue:#{queue}", "queue:#{another_queue}", timeout])
   end
 
   it 'should retrieve work', queuing: true do


### PR DESCRIPTION
This broke with https://github.com/enova/sidekiq-rate-limiter/commit/b33fa68e4c338adc40c471c87a298e07e500ae75

Expanding the Travis matrix to catch this in the future