### PR TITLE
Fix interval bug in fetch.rb

### DIFF
--- a/lib/sidekiq-rate-limiter/fetch.rb
+++ b/lib/sidekiq-rate-limiter/fetch.rb
@@ -27,7 +27,7 @@ module Sidekiq::RateLimiter
 
       options = {
         :limit    => (limit.respond_to?(:call) ? limit.call(*args) : limit).to_i,
-        :interval => (interval.respond_to?(:call) ? interval.call(*args) : interval).to_f,
+        :interval => (interval.respond_to?(:call) ? interval.call(*args) : interval).to_i,
         :name     => (name.respond_to?(:call) ? name.call(*args) : name).to_s,
       }
 


### PR DESCRIPTION
On line #40 `limit` uses `redis_rate_limiter` to [call](https://github.com/seanxiesx/redis_rate_limiter/blob/master/lib/redis_rate_limiter.rb#L38) `EXPIRE` with interval as a parameter. Since `EXPIRE` only accepts [integers](https://github.com/antirez/redis/blob/unstable/src/expire.c#L230), this causes `lim.add` to fail. Since `redis_rate_limiter` use a `multi` block, `lim.add` fails silently instead of raising an error:

![image](https://cloud.githubusercontent.com/assets/2660212/17313679/5f4fdc48-5823-11e6-9dd4-01e52b471733.png)

This means that nothing is added to the rate limit queue, so no jobs are actually rate limited. This PR fixes this bug by casting to an integer instead of a float.
