### PR TITLE
Pluggable fetch strategies

### DIFF
--- a/lib/sidekiq-rate-limiter.rb
+++ b/lib/sidekiq-rate-limiter.rb
@@ -1,2 +1,22 @@
 require 'sidekiq-rate-limiter/version'
 require 'sidekiq-rate-limiter/fetch'
+require 'sidekiq-rate-limiter/configuration'
+
+module Sidekiq::RateLimiter
+  class << self
+    attr_writer :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+end

--- a/lib/sidekiq-rate-limiter/basic_strategy.rb
+++ b/lib/sidekiq-rate-limiter/basic_strategy.rb
@@ -1,0 +1,16 @@
+module Sidekiq::RateLimiter
+  class BasicStrategy
+    def call(work, klass, options)
+      Sidekiq.redis do |conn|
+        lim = Limit.new(conn, options)
+        if lim.exceeded?(klass)
+          conn.lpush("queue:#{work.queue_name}", work.respond_to?(:message) ? work.message : work.job)
+          nil
+        else
+          lim.add(klass)
+          work
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq-rate-limiter/configuration.rb
+++ b/lib/sidekiq-rate-limiter/configuration.rb
@@ -1,0 +1,9 @@
+module Sidekiq::RateLimiter
+  class Configuration
+    attr_accessor :fetch_strategy
+
+    def initialize
+      @fetch_strategy = Sidekiq::RateLimiter::BasicStrategy
+    end
+  end
+end

--- a/lib/sidekiq-rate-limiter/fetch.rb
+++ b/lib/sidekiq-rate-limiter/fetch.rb
@@ -4,6 +4,7 @@ require 'sidekiq/fetch'
 require 'redis_rate_limiter'
 require 'sidekiq-rate-limiter/basic_strategy'
 require 'sidekiq-rate-limiter/sleep_strategy'
+require 'sidekiq-rate-limiter/schedule_in_future_strategy'
 
 module Sidekiq::RateLimiter
   DEFAULT_LIMIT_NAME =
@@ -33,7 +34,7 @@ module Sidekiq::RateLimiter
         :name     => (name.respond_to?(:call) ? name.call(*args) : name).to_s,
       }
 
-      fetch_strategy.call(work, klass, options)
+      fetch_strategy.call(work, klass, args, options)
     end
 
     def fetch_strategy

--- a/lib/sidekiq-rate-limiter/sleep_strategy.rb
+++ b/lib/sidekiq-rate-limiter/sleep_strategy.rb
@@ -1,6 +1,6 @@
 module Sidekiq::RateLimiter
   class SleepStrategy
-    def call(work, klass, options)
+    def call(work, klass, args, options)
       Sidekiq.redis do |conn|
         lim = Limit.new(conn, options)
         if lim.exceeded?(klass)

--- a/lib/sidekiq-rate-limiter/sleep_strategy.rb
+++ b/lib/sidekiq-rate-limiter/sleep_strategy.rb
@@ -1,0 +1,25 @@
+module Sidekiq::RateLimiter
+  class SleepStrategy
+    def call(work, klass, options)
+      Sidekiq.redis do |conn|
+        lim = Limit.new(conn, options)
+        if lim.exceeded?(klass)
+          # if this job is being rate-limited for longer than 1 second, sleep for that amount
+          # of time before putting the job back on the queue.
+          #
+          # This is undesirable as it ties up the sidekiq thread for one second, but it does help in situations where
+          # high redis/sidekiq CPU usage is causing problems.
+
+          if lim.retry_in?(klass) > 1.0
+            sleep(1)
+          end
+          conn.lpush("queue:#{work.queue_name}", work.respond_to?(:message) ? work.message : work.job)
+          nil
+        else
+          lim.add(klass)
+          work
+        end
+      end
+    end
+  end
+end

--- a/spec/sidekiq-rate-limiter/configure_spec.rb
+++ b/spec/sidekiq-rate-limiter/configure_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe "#configure" do
+  context 'default' do
+    it 'should have the basic strategy by default' do
+      expect(Sidekiq::RateLimiter.configuration.fetch_strategy).to eq(Sidekiq::RateLimiter::BasicStrategy)
+    end
+  end
+
+  context 'with a strategy set' do
+    before :each do
+      Sidekiq::RateLimiter.configure do |config|
+        config.fetch_strategy = Sidekiq::RateLimiter::SleepStrategy
+      end
+    end
+
+    it 'should have the sleep strategy if set' do
+      expect(Sidekiq::RateLimiter.configuration.fetch_strategy).to eq(Sidekiq::RateLimiter::SleepStrategy)
+    end
+
+    after :each do
+      Sidekiq::RateLimiter.reset
+    end
+  end
+end

--- a/spec/sidekiq-rate-limiter/fetch_spec.rb
+++ b/spec/sidekiq-rate-limiter/fetch_spec.rb
@@ -123,6 +123,35 @@ RSpec.describe Sidekiq::RateLimiter::Fetch do
     end
   end
 
+  context 'with the schedule in the future strategy' do
+    before :each do
+      Sidekiq::RateLimiter.configure do |config|
+        config.fetch_strategy = Sidekiq::RateLimiter::ScheduleInFutureStrategy
+      end
+    end
+
+    it 'should place rate-limited work at the back of the queue', queuing: true do
+      worker.perform_async(*args)
+      expect_any_instance_of(Sidekiq::RateLimiter::Limit).to receive(:exceeded?).and_return(true)
+
+      expect_any_instance_of(Sidekiq::RateLimiter::Limit).to receive(:retry_in?).and_return(100)
+
+      fetch = described_class.new(options)
+      expect(fetch.retrieve_work).to be_nil
+
+      # expect the job to move to being scheduled in the future
+      q = Sidekiq::Queue.new(queue)
+      expect(q.size).to eq(0)
+
+      ss = Sidekiq::ScheduledSet.new
+      expect(ss.size).to eq(1)
+    end
+
+    after :each do
+      Sidekiq::RateLimiter.reset
+    end
+  end
+
   it 'should accept procs for limit, name, and period config keys', queuing: true do
     proc_worker.perform_async(1,2)
 


### PR DESCRIPTION
This PR adds the ability to have different pluggable strategies for what to do when the rate limit is exceeded. 

For now there are new strategies that sleep or schedule jobs to run in the future. Added these in order to deal with issues described here https://github.com/enova/sidekiq-rate-limiter/issues/2