### PR TITLE
Make limit check and additions an atomic operation

### DIFF
--- a/lib/sidekiq-rate-limiter/fetch.rb
+++ b/lib/sidekiq-rate-limiter/fetch.rb
@@ -32,7 +32,7 @@ module Sidekiq::RateLimiter
       }
 
       Sidekiq.redis do |conn|
-        s = Redis::Semaphore.new(:sidekiq_rate_limit_exceeded_check, redis: conn)
+        s = Redis::Semaphore.new(:sidekiq_rate_limit_exceeded_check, redis: Sidekiq::RedisConnection.create, stale_client_timeout: 60)
         lim = Limit.new(conn, options)
         limit_exceeded = nil
 

--- a/sidekiq-rate-limiter.gemspec
+++ b/sidekiq-rate-limiter.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency "sidekiq", ">= 4.0", "< 6.0"
   s.add_dependency "redis_rate_limiter"
+  s.add_dependency "redis-semaphore"
 end

--- a/spec/sidekiq-rate-limiter/fetch_spec.rb
+++ b/spec/sidekiq-rate-limiter/fetch_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe Sidekiq::RateLimiter::Fetch do
   it 'should place rate-limited work at the back of the queue', queuing: true do
     worker.perform_async(*args)
     expect_any_instance_of(Sidekiq::RateLimiter::Limit).to receive(:exceeded?).and_return(true)
-    expect_any_instance_of(redis_class).to receive(:lpush).exactly(:once).and_call_original
+    expect_any_instance_of(redis_class).to receive(:lpush).with("SEMAPHORE:sidekiq_rate_limit_exceeded_check:AVAILABLE", anything).exactly(:once).and_call_original
+    expect_any_instance_of(redis_class).to receive(:lpush).with("queue:basic", anything).exactly(:once).and_call_original
 
     fetch = described_class.new(options)
     expect(fetch.retrieve_work).to be_nil


### PR DESCRIPTION
Hi! We were having problems with a very limited API that only allows us to do a couple of requests per second and tried to use this gem, but we've been seeing issues with a highly loaded queue.

We found that due to the fact that checking whether the limit is exceeded and adding a new item to the list are different operations, if two sidekiq jobs are performed at the same time and check for the limit at the same time, both can be returned true, and proceed with executing the work.

The addition of a semaphore for the check & add to limit operations ensures that it's only done by one job at the time, and fixes the race condition.