### PR TITLE
Cast interval to an integer, not a float

### DIFF
--- a/lib/sidekiq-rate-limiter/fetch.rb
+++ b/lib/sidekiq-rate-limiter/fetch.rb
@@ -26,7 +26,7 @@ module Sidekiq::RateLimiter
 
       options = {
         :limit    => (limit.respond_to?(:call) ? limit.call(*args) : limit).to_i,
-        :interval => (interval.respond_to?(:call) ? interval.call(*args) : interval).to_f,
+        :interval => (interval.respond_to?(:call) ? interval.call(*args) : interval).to_i,
         :name     => (name.respond_to?(:call) ? name.call(*args) : name).to_s,
       }
 


### PR DESCRIPTION
Fixes https://github.com/enova/sidekiq-rate-limiter/issues/30 by avoiding "ERR value is not an integer or out of range" errors.

The `interval` for a RedisRateLimiter instance must be an integer, according to the [RedisRateLimiter documentation](https://www.rubydoc.info/github/seanxiesx/redis_rate_limiter/master/RedisRateLimiter#interval-instance_method).