### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/sidekiq-rate-limiter.gemspec
+++ b/sidekiq-rate-limiter.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/enova/sidekiq-rate-limiter"
   s.summary     = %q{Redis-backed, per-worker rate limits for job processing}
   s.description = %q{Redis-backed, per-worker rate limits for job processing}
-  s.rubyforge_project = "nowarning"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436