### PR TITLE
Add support for new Sidekiq's configuration model

### DIFF
--- a/lib/sidekiq-rate-limiter/server.rb
+++ b/lib/sidekiq-rate-limiter/server.rb
@@ -2,5 +2,12 @@ require 'sidekiq-rate-limiter/version'
 require 'sidekiq-rate-limiter/fetch'
 
 Sidekiq.configure_server do |config|
-  Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch
+  # Backwards compatibility for Sidekiq < 6.1.0 (see https://github.com/mperham/sidekiq/pull/4602 for details)
+  if (Sidekiq::BasicFetch.respond_to?(:bulk_requeue))
+    Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch
+  elsif (Sidekiq::VERSION < '6.5.0') # Sidekiq config was redesigned in https://github.com/mperham/sidekiq/pull/5340
+    Sidekiq.options[:fetch] = Sidekiq::RateLimiter::Fetch.new(Sidekiq.options)
+  else
+    Sidekiq[:fetch] = Sidekiq::RateLimiter::Fetch.new(Sidekiq)
+  end
 end


### PR DESCRIPTION
The change in Sidekiq is part of an ongoing refactoring that will deprecate the existing configuration mechanism in v7 and was introduced in https://github.com/mperham/sidekiq/pull/5340.

Supercedes https://github.com/enova/sidekiq-rate-limiter/pull/39 (enabling to use with 6.1.0 < Sidekiq < 6.5.0 and Sidekiq > 6.5.0